### PR TITLE
fix parentheses in mason-update-all

### DIFF
--- a/mason.el
+++ b/mason.el
@@ -1578,8 +1578,8 @@ indicating a package success to update."
       (mason--info "No updates available")
     (maphash
      (lambda (p _)
-       (mason-update p nil callback)
-       mason--updatable))))
+       (mason-update p nil callback))
+       mason--updatable)))
 
 (defun mason--install-0 (spec force interactive uninstall callback)
   "Implementation of `mason-install' and `mason-uninstall'.


### PR DESCRIPTION
Sorry deirn, I made a mistake.

This commit fixes misplaced parentheses in `mason-update-all`. `mason--updatable` should be outside of the lambda.